### PR TITLE
Handle async LDAP handlers when updating bindDN

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -429,7 +429,33 @@ function Server (options) {
 
         try {
           const next = messageIIFE
-          if (chain.handlers[i]) { return chain.handlers[i++].call(chain.backend, req, res, next) }
+
+          if (chain.handlers[i]) {
+            const handlerResult = chain.handlers[i++].call(chain.backend, req, res, next)
+
+            // If handler returns a Promise (async handler), wait for it to complete
+            if (handlerResult && typeof handlerResult.then === 'function') {
+              return handlerResult.then(() => {
+                // After async handler completes, check if we need to update bindDN
+                if (req.protocolOp === Protocol.operations.LDAP_REQ_BIND && res.status === 0) {
+                  if (req.dn.length === 0 && req.credentials === '') {
+                    conn.ldap.bindDN = new DN({ rdns: [new RDN({ cn: 'anonymous' })] })
+                  } else {
+                    conn.ldap.bindDN = DN.fromString(req.dn)
+                  }
+                }
+
+                if (req.protocolOp === Protocol.operations.LDAP_REQ_UNBIND && res.status === 0) {
+                  conn.ldap.bindDN = new DN({ rdns: [new RDN({ cn: 'anonymous' })] })
+                }
+              }).catch((err) => {
+                // If async handler throws, treat it as an error
+                return messageIIFE(err)
+              })
+            }
+
+            return handlerResult
+          }
 
           if (req.protocolOp === Protocol.operations.LDAP_REQ_BIND && res.status === 0) {
             // 0 length == anonymous bind

--- a/lib/server.js
+++ b/lib/server.js
@@ -401,6 +401,25 @@ function Server (options) {
 
       const chain = self._getHandlerChain(req, res)
 
+      // Helper function to update bindDN based on request/response
+      // Note: Should only be called after res.end() to ensure res.status is set
+      function updateBindDN () {
+        if (req.protocolOp === Protocol.operations.LDAP_REQ_BIND && res.status === 0) {
+          // 0 length == anonymous bind
+          if (req.dn.length === 0 && req.credentials === '') {
+            conn.ldap.bindDN = new DN({ rdns: [new RDN({ cn: 'anonymous' })] })
+          } else {
+            conn.ldap.bindDN = DN.fromString(req.dn)
+          }
+        }
+
+        // unbind clear bindDN for safety
+        // conn should terminate on unbind (RFC4511 4.3)
+        if (req.protocolOp === Protocol.operations.LDAP_REQ_UNBIND && res.status === 0) {
+          conn.ldap.bindDN = new DN({ rdns: [new RDN({ cn: 'anonymous' })] })
+        }
+      }
+
       let i = 0
       return (function messageIIFE (err) {
         function sendError (sendErr) {
@@ -431,46 +450,26 @@ function Server (options) {
           const next = messageIIFE
 
           if (chain.handlers[i]) {
-            const handlerResult = chain.handlers[i++].call(chain.backend, req, res, next)
+            const handler = chain.handlers[i++]
+            const handlerResult = handler.call(chain.backend, req, res, next)
 
-            // If handler returns a Promise (async handler), wait for it to complete
+            // If handler returns a Promise, handle async path
             if (handlerResult && typeof handlerResult.then === 'function') {
-              return handlerResult.then(() => {
-                // After async handler completes, check if we need to update bindDN
-                if (req.protocolOp === Protocol.operations.LDAP_REQ_BIND && res.status === 0) {
-                  if (req.dn.length === 0 && req.credentials === '') {
-                    conn.ldap.bindDN = new DN({ rdns: [new RDN({ cn: 'anonymous' })] })
-                  } else {
-                    conn.ldap.bindDN = DN.fromString(req.dn)
-                  }
-                }
-
-                if (req.protocolOp === Protocol.operations.LDAP_REQ_UNBIND && res.status === 0) {
-                  conn.ldap.bindDN = new DN({ rdns: [new RDN({ cn: 'anonymous' })] })
-                }
-              }).catch((err) => {
-                // If async handler throws, treat it as an error
-                return messageIIFE(err)
-              })
+              return handlerResult
+                .then(() => {
+                  // Continue the handler chain by calling next
+                  return messageIIFE()
+                })
+                .catch((err) => {
+                  return messageIIFE(err)
+                })
             }
 
             return handlerResult
           }
 
-          if (req.protocolOp === Protocol.operations.LDAP_REQ_BIND && res.status === 0) {
-            // 0 length == anonymous bind
-            if (req.dn.length === 0 && req.credentials === '') {
-              conn.ldap.bindDN = new DN({ rdns: [new RDN({ cn: 'anonymous' })] })
-            } else {
-              conn.ldap.bindDN = DN.fromString(req.dn)
-            }
-          }
-
-          // unbind clear bindDN for safety
-          // conn should terminate on unbind (RFC4511 4.3)
-          if (req.protocolOp === Protocol.operations.LDAP_REQ_UNBIND && res.status === 0) {
-            conn.ldap.bindDN = new DN({ rdns: [new RDN({ cn: 'anonymous' })] })
-          }
+          // No more handlers - update bindDN and call after chain
+          updateBindDN()
 
           return after()
         } catch (e) {


### PR DESCRIPTION
Handle async LDAP handlers when updating bindDN

- Add support for Promise-based (async) LDAP handlers
- Extract bindDN update logic into shared helper function to eliminate code duplication
- Ensure BIND/UNBIND operations correctly update bindDN after handler completion
